### PR TITLE
♻️ refactor: 피드백 반영한 리팩토링

### DIFF
--- a/src/components/auth/MyPageForm.jsx
+++ b/src/components/auth/MyPageForm.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { IoIosMail } from 'react-icons/io';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import defaultProfileImage from '../../assets/images/memoticon.png';
 import useUserStore from '../../store/useUserStore';
 import RecipeList from '../common/RecipeList/RecipeList';
@@ -8,23 +8,11 @@ import { useGetMyRecipes } from '../shared/hooks/useRecipeQueries';
 
 const MyPageForm = () => {
   const { user } = useUserStore();
-  const navigate = useNavigate();
   const { data: myRecipes, isLoading } = useGetMyRecipes(user?.id);
-
-  useEffect(() => {
-    if (!user) {
-      navigate('/');
-    }
-  }, [user, navigate]);
 
   // 로딩 중일 때 처리
   if (isLoading) {
     return <div>Loading...</div>;
-  }
-
-  // user가 없거나 myRecipes가 undefined일 때 처리
-  if (!user || !myRecipes) {
-    return null; // 또는 리디렉션이 되기 전까지 빈 화면 유지
   }
 
   return (

--- a/src/components/recipe/RecipeForm/RecipeForm.jsx
+++ b/src/components/recipe/RecipeForm/RecipeForm.jsx
@@ -12,9 +12,6 @@ const RecipeForm = ({ existingRecipe }) => {
   const [selectedFile, setSelectedFile] = useState(null);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [initialTitle, setInitialTitle] = useState('');
-  const [initialContent, setInitialContent] = useState('');
-  const [initialImageSrc, setInitialImageSrc] = useState('https://via.placeholder.com/200');
   const navigate = useNavigate();
   const { user } = useUserStore();
 
@@ -23,9 +20,6 @@ const RecipeForm = ({ existingRecipe }) => {
 
   useEffect(() => {
     if (existingRecipe) {
-      setInitialTitle(existingRecipe.title);
-      setInitialContent(existingRecipe.content);
-      setInitialImageSrc(existingRecipe.thumbnail || 'https://via.placeholder.com/200');
       setTitle(existingRecipe.title);
       setContent(existingRecipe.content);
       setImageSrc(existingRecipe?.thumbnail || 'https://via.placeholder.com/200');
@@ -78,9 +72,11 @@ const RecipeForm = ({ existingRecipe }) => {
   };
 
   const handleCancelEdit = () => {
-    setTitle(initialTitle);
-    setContent(initialContent);
-    setImageSrc(initialImageSrc);
+    if (existingRecipe) {
+      setTitle(existingRecipe.title);
+      setContent(existingRecipe.content);
+      setImageSrc(existingRecipe.thumbnail || 'https://via.placeholder.com/200');
+    }
     setSelectedFile(null);
     navigate(-1);
   };

--- a/src/components/shared/hooks/useRecipes.js
+++ b/src/components/shared/hooks/useRecipes.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { useGetRecipes } from './useRecipeQueries';
+
+export const useRecipes = (searchTerm) => {
+  const { data: recipes } = useGetRecipes();
+  const [filteredRecipes, setFilteredRecipes] = useState([]);
+
+  useEffect(() => {
+    if (recipes) {
+      setFilteredRecipes(recipes);
+    }
+  }, [recipes]);
+
+  useEffect(() => {
+    if (recipes) {
+      const filtered = recipes.filter((recipe) => recipe.title.toLowerCase().includes(searchTerm.toLowerCase()));
+      setFilteredRecipes(filtered);
+    }
+    window.scrollTo(0, 0); // 검색 시 스크롤 위치를 상단으로 이동, 화면 흔들림 방지
+  }, [searchTerm, recipes]);
+
+  return filteredRecipes;
+};

--- a/src/components/shared/hooks/useTimeOfDay.js
+++ b/src/components/shared/hooks/useTimeOfDay.js
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+import { getCurrentTimeOfDay } from '../utils/getCurrentTimeOfDay';
+
+export const useTimeOfDay = () => {
+  const [time, setTime] = useState('');
+
+  useEffect(() => {
+    const timeOfDay = getCurrentTimeOfDay();
+    setTime(timeOfDay);
+  }, []);
+
+  return time;
+};

--- a/src/pages/CommitRecipePage/CommitRecipePage.jsx
+++ b/src/pages/CommitRecipePage/CommitRecipePage.jsx
@@ -1,19 +1,11 @@
-import React, { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React from 'react';
+import { useParams } from 'react-router-dom';
 
 import RecipeForm from '../../components/recipe/RecipeForm';
 import { useRecipeDetail } from '../../components/shared/hooks/useRecipeQueries';
-import useUserStore from '../../store/useUserStore';
 
 const CommitRecipePage = () => {
   const { recipeId } = useParams();
-  const { user } = useUserStore();
-  const navigate = useNavigate();
-  useEffect(() => {
-    if (!user) {
-      navigate('/');
-    }
-  }, [user, navigate]);
 
   const { data: existingRecipe } = useRecipeDetail(recipeId);
 

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,5 +1,5 @@
 import SearchIcon from '@mui/icons-material/Search';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { LuPointer } from 'react-icons/lu';
 import { Link } from 'react-router-dom';
 
@@ -7,38 +7,18 @@ import MainImage from '../../assets/images/MainImage.jpg';
 
 import RecipeList from '../../components/common/RecipeList/RecipeList';
 import SurveyModal from '../../components/modals/SurveyModal';
-import { useGetRecipes } from '../../components/shared/hooks/useRecipeQueries';
-import { getCurrentTimeOfDay } from '../../components/shared/utils/getCurrentTimeOfDay';
-import useMainStore from '../../store/useMainStore';
+import { useRecipes } from '../../components/shared/hooks/useRecipes';
+import { useTimeOfDay } from '../../components/shared/hooks/useTimeOfDay';
 
 const MainPage = () => {
-  const { data: recipes, error } = useGetRecipes();
-  const { filteredRecipes, searchTerm, setSearchTerm } = useMainStore();
+  const [searchTerm, setSearchTerm] = useState('');
+  const filteredRecipes = useRecipes(searchTerm);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [time, setTime] = useState('');
-
-  useEffect(() => {
-    if (recipes) {
-      // 전체 레시피 목록을 전역 상태에 저장
-      useMainStore.getState().setRecipes(recipes);
-    }
-
-    // 시간대 설정 함수 호출
-    const timeOfDay = getCurrentTimeOfDay();
-    setTime(timeOfDay);
-  }, [recipes]);
-
-  const handleSearch = useCallback(() => {
-    setSearchTerm(searchTerm); // onSearch 속성 제거, setSearchTerm으로 직접 검색어 상태 업데이트
-  }, [searchTerm, setSearchTerm]);
+  const time = useTimeOfDay();
 
   const handleModalToggle = () => {
     setIsModalOpen(!isModalOpen);
   };
-
-  useEffect(() => {
-    window.scrollTo(0, 0); // 검색 시 스크롤 위치를 상단으로 이동, 화면 흔들림 방지
-  }, [searchTerm]);
 
   return (
     <div>
@@ -71,8 +51,9 @@ const MainPage = () => {
             className="outline-none w-40 sm:w-64 text-sm"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
+            aria-label="검색어 입력"
           />
-          <button className="outline-none" onClick={handleSearch}>
+          <button className="outline-none" aria-label="검색">
             <SearchIcon />
           </button>
         </div>

--- a/src/routers/requireAuthLoader.js
+++ b/src/routers/requireAuthLoader.js
@@ -1,0 +1,12 @@
+import { redirect } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import useUserStore from '../store/useUserStore';
+
+export const requireAuthLoader = () => {
+  const { user } = useUserStore.getState();
+  if (!user) {
+    toast.warn('로그인 후 이용 해주세요.');
+    return redirect('/logIn');
+  }
+  return null;
+};

--- a/src/routers/router.jsx
+++ b/src/routers/router.jsx
@@ -10,6 +10,7 @@ import MainPage from '../pages/MainPage';
 import MyPage from '../pages/MyPage/MyPage';
 import RecipeDetail from '../pages/RecipeDetail';
 import MainLayout from '../styles/MainLayout/MainLayout';
+import { requireAuthLoader } from './requireAuthLoader';
 
 const router = createBrowserRouter([
   {
@@ -22,7 +23,8 @@ const router = createBrowserRouter([
       },
       {
         path: '/recipe',
-        element: <CommitRecipePage />
+        element: <CommitRecipePage />,
+        loader: requireAuthLoader
       },
       {
         path: '/recipe/:recipeId',
@@ -30,11 +32,13 @@ const router = createBrowserRouter([
       },
       {
         path: '/recipe/:recipeId/edit',
-        element: <CommitRecipePage />
+        element: <CommitRecipePage />,
+        loader: requireAuthLoader
       },
       {
         path: '/',
         element: <MyPage />,
+        loader: requireAuthLoader,
         children: [
           { path: '/myPage', element: <MyPageForm /> },
           { path: '/modify', element: <MyPageModify /> }

--- a/src/store/useModalStore.js
+++ b/src/store/useModalStore.js
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 
 const useModalStore = create((set) => ({
   currentPage: 0,
-  totalPages: 7,
+  totalPages: 8,
   nextPage: () =>
     set((state) => ({
       currentPage: state.currentPage + 1 < state.totalPages ? state.currentPage + 1 : state.currentPage


### PR DESCRIPTION
MainPage.jsx
useQuery를 사용해서 가져온 정보를 zustand 스토어로 옮기는 이유 X
지역에서만 사용되는 데이터를 전역 공간에서 관리하는 것의 단점을 알아 보면 좋을 것 같습니다.
수정한 내용:
zustand스토어로 상태 관리한 것을 지역 상태 관리로 수정 및 커스텀 훅 생성

RecipeForm.jsx
'어떤 데이터를 state로 관리해야할까?'를 고민해보시면 좋을 것 같습니다. initial*** 종류의 state는 초기에 한번 set되면 더 이상 변경이 발생하지 않습니다. 이러한 데이터들은 이미 existingRecipe라는 변수에 있는 정보이기 때문에 상태로 관리하지 않아도 좋을 것 같습니다.
수정한 내용:
initial*** 에 상태로 저장하지 않고 existingRecipe로 수정해서 취소 버튼 시 데이터 불러오기.

CommitRecipePage.jsx
유저의 존재 유무는 router 수준에서 확인하는 방향으로 작업하는 것도 좋습니다.
수정한 내용:
router의 loader를 사용

- redirect는 데이터 로딩 또는 서버 사이드 렌더링 시 사용되며, 리액트 라우터의 loader나 action 함수 내에서 사용.
- 페이지를 렌더링하기 전에 리다이렉션이 발생

- navigate는 클라이언트 사이드 렌더링 시 사용되며 리액트 컴포넌트의 이벤트 핸들러에서 사용.
-이미 렌더링된 컴포넌트에서 페이지 이동을 트리거